### PR TITLE
Fix unreal intermittent crash when changing settings.

### DIFF
--- a/Source/BYGYouTrackFiller/Private/BYGYouTrackFillerModule.cpp
+++ b/Source/BYGYouTrackFiller/Private/BYGYouTrackFillerModule.cpp
@@ -40,6 +40,7 @@ void FBYGYouTrackFillerModule::UnregisterCheats()
 	{
 		IConsoleManager::Get().UnregisterConsoleObject(ConsoleCommand);
 	}
+	ConsoleCommands.Empty();
 }
 
 void FBYGYouTrackFillerModule::FillAndShowYouTrack(const TArray<FString>& Args)


### PR DESCRIPTION
we forgot to clear the ConsoleCommands array after unregistering the commands from the console manager. which caused the engine try to unregister a console command that didn't exist the next time UnregisterCheats was called.

also sorry for the pull request on a stale repo.